### PR TITLE
Fix "Task function must be specified" error after gulp 4.x update

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -394,4 +394,4 @@ gulp.task('updateReadme', function (done) {
     done();
 });
 
-gulp.task('default', ['updatePackages', 'updateReadme']);
+gulp.task('default', gulp.series('updatePackages', 'updateReadme'));


### PR DESCRIPTION
@Apollon77 - You forgot something important ;-)