### PR TITLE
Enhancement: Show also the date of an alarm, not only the time

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Alarm (Wecker) settings for each device, if available.
 | State name | meaning | value |
 | - | - | - |
 | enabled | Shows status of alarm and allows to change it: Activate alarm with true - Deactivate alarm with false | true / false |
+| date | Shows date of alarm, may also depend on recurringPattern | Date Output |
 | time | Time for alarm. Overwrite the time for existing alarm to set a new time for this alarm. In case you have an existing alarm you can change the time here by simply overwrite the time in format hh:mm:ss, seconds are not needed to set | Time Input |
 | triggered | true if alarm is reached and triggered. Clock must be in sync with Amazon and iobroker, Use this to trigger other action as soon as the alarm time is reached | true / false |
 | recurringPattern | Shows the recurring pattern of alarm | 0 = one time, no recurring <br> P1D = daily <br> XXXX-WD = on weekdays <br> XXXX-WE = on weekends <br> XXXX-WXX-1 = every monday <br> XXXX-WXX-2 = every tuesday <br> XXXX-WXX-3 = every wednesday <br> XXXX-WXX-4 = every thursday <br> XXXX-WXX-5 = every friday <br> XXXX-WXX-6 = every saturday <br> XXXX-WXX-7 = every sunday |

--- a/main.js
+++ b/main.js
@@ -2057,7 +2057,8 @@ function createNotificationStates(serialOrName) {
                 if (time.endsWith('.000')) time = time.substr(0, time.length - 4);
                 const displayTime = noti.originalTime.substr(0, noti.originalTime.length - 4);
                 setOrUpdateObject(notiId, {type: 'channel', common: {name: noti.reminderLabel || displayTime}});
-                setOrUpdateObject(notiId + '.time', {common: {type: 'mixed', role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Time'}}, time, noti.set);
+                setOrUpdateObject(notiId + '.date', {common: {type: 'mixed', read: true, write: false, role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Date'}}, noti.originalDate);
+		setOrUpdateObject(notiId + '.time', {common: {type: 'mixed', role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Time'}}, time, noti.set);
                 setOrUpdateObject(notiId + '.enabled', {common: {type: 'boolean', role: 'switch.enable', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Enabled'}}, (noti.status === 'ON'), noti.set);
                 setOrUpdateObject(notiId + '.triggered', {common: {type: 'boolean', read: true, write: false, role: 'indicator', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Triggered'}}, false);
                 setOrUpdateObject(notiId + '.recurringPattern', {common: {type: 'string', read: true, write: false, role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' RecurringPattern'}}, noti.recurringPattern || '0');

--- a/main.js
+++ b/main.js
@@ -2058,7 +2058,7 @@ function createNotificationStates(serialOrName) {
                 const displayTime = noti.originalTime.substr(0, noti.originalTime.length - 4);
                 setOrUpdateObject(notiId, {type: 'channel', common: {name: noti.reminderLabel || displayTime}});
                 setOrUpdateObject(notiId + '.date', {common: {type: 'mixed', read: true, write: false, role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Date'}}, noti.originalDate);
-		setOrUpdateObject(notiId + '.time', {common: {type: 'mixed', role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Time'}}, time, noti.set);
+                setOrUpdateObject(notiId + '.time', {common: {type: 'mixed', role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Time'}}, time, noti.set);
                 setOrUpdateObject(notiId + '.enabled', {common: {type: 'boolean', role: 'switch.enable', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Enabled'}}, (noti.status === 'ON'), noti.set);
                 setOrUpdateObject(notiId + '.triggered', {common: {type: 'boolean', read: true, write: false, role: 'indicator', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' Triggered'}}, false);
                 setOrUpdateObject(notiId + '.recurringPattern', {common: {type: 'string', read: true, write: false, role: 'state', name: noti.reminderLabel ? noti.reminderLabel : displayTime + ' RecurringPattern'}}, noti.recurringPattern || '0');


### PR DESCRIPTION
So far, only the time of an alarm is shown; especially by using the recurringPattern, the alarm can take place on different days. It is therefore necessary to know the date of the next triggering (works if the alarm is also enabled).