### PR TITLE
FEAT: Add duration to activeTimerList

### DIFF
--- a/README.md
+++ b/README.md
@@ -505,6 +505,10 @@ If you region is not present, and you find out the value, do not hesitate to enr
 
 ## Changelog
 <!-- ### __WORK IN PROGRESS__ -->
+
+### __WORK IN PROGRESS__
+* (MiRo1310) Adds durationMillis to the activeTimerList
+
 ### 3.27.4 (2025-11-06)
 * (@Apollon77) Adjusts authentication check to recent Amazon changes
 

--- a/main.js
+++ b/main.js
@@ -3527,7 +3527,8 @@ function createNotificationStates(serialOrName) {
                     activeTimerList.push({
                         id: noti.notificationIndex,
                         triggerTime: noti.triggerTime || Date.now() + remainingTime,
-                        label: noti.timerLabel
+                        label: noti.timerLabel,
+                        durationMillis: noti.originalDurationInMillis
                     });
                     if (notificationTimer[noti.id]) {
                         clearTimeout(notificationTimer[noti.id]);


### PR DESCRIPTION
To avoid having to listen to two data points in the Alexa-Timer-Vis adapter, it would be very helpful if the value were included in the ActiveTimerList. Since I'm completely redesigning the adapter so it can be used with all languages, it would be great if this could be integrated.

Thank you.