### PR TITLE
Default proxyOwnIp to admin bind IP

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -21,36 +21,15 @@
             getIPs(function (ips) {
                 var str = '';
                 var existingFound = false;
-                // When no value is stored yet, prefer the host that admin is currently accessed
-                // through. That is the address the user reaches ioBroker on, so the cookie proxy URL
-                // built from it will work for them. Falls back to the first listed IP otherwise.
-                var adminHost = '';
-                try {
-                    adminHost = (window.location && window.location.hostname) || '';
-                } catch (e) { /* ignore */ }
-                if (adminHost === 'localhost' || adminHost === '127.0.0.1' || adminHost === '::1') {
-                    adminHost = '';
-                }
-                var preferAdminHost = !actualAddr && adminHost;
-                var preferredMatched = false;
                 for (var i = 0; i < ips.length; i++) {
                     if (ips[i].family === 'ipv6') continue;
                     if (ips[i].address === '0.0.0.0') continue;
                     if (ips[i].address === '127.0.0.1') continue;
                     if (ips[i].address === actualAddr) existingFound = true;
-                    var selectThis = actualAddr
-                        ? ips[i].address === actualAddr
-                        : (preferAdminHost && ips[i].address === adminHost && !preferredMatched);
-                    if (selectThis && preferAdminHost) preferredMatched = true;
-                    str += '<option value="' + ips[i].address + '" ' + (selectThis ? 'selected' : '') + '>' + ips[i].name + '</option>';
+                    str += '<option value="' + ips[i].address + '" ' + ((ips[i].address === actualAddr) ? 'selected' : '') + '>' + ips[i].name + '</option>';
                 }
                 if (!existingFound && actualAddr) {
                     str = '<option value="' + actualAddr + '" selected> Please change INVALID!!' + actualAddr + '</option>' + str;
-                } else if (preferAdminHost && !preferredMatched) {
-                    // Admin host (e.g. hostname or reverse-proxy IP) is not in the host's IP list.
-                    // Offer it as a preselected option so the URL we build later matches what the
-                    // user already uses to reach ioBroker.
-                    str = '<option value="' + adminHost + '" selected>' + adminHost + ' (admin host)</option>' + str;
                 }
 
                 $(id).html(str);

--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -21,15 +21,36 @@
             getIPs(function (ips) {
                 var str = '';
                 var existingFound = false;
+                // When no value is stored yet, prefer the host that admin is currently accessed
+                // through. That is the address the user reaches ioBroker on, so the cookie proxy URL
+                // built from it will work for them. Falls back to the first listed IP otherwise.
+                var adminHost = '';
+                try {
+                    adminHost = (window.location && window.location.hostname) || '';
+                } catch (e) { /* ignore */ }
+                if (adminHost === 'localhost' || adminHost === '127.0.0.1' || adminHost === '::1') {
+                    adminHost = '';
+                }
+                var preferAdminHost = !actualAddr && adminHost;
+                var preferredMatched = false;
                 for (var i = 0; i < ips.length; i++) {
                     if (ips[i].family === 'ipv6') continue;
                     if (ips[i].address === '0.0.0.0') continue;
                     if (ips[i].address === '127.0.0.1') continue;
                     if (ips[i].address === actualAddr) existingFound = true;
-                    str += '<option value="' + ips[i].address + '" ' + ((ips[i].address === actualAddr) ? 'selected' : '') + '>' + ips[i].name + '</option>';
+                    var selectThis = actualAddr
+                        ? ips[i].address === actualAddr
+                        : (preferAdminHost && ips[i].address === adminHost && !preferredMatched);
+                    if (selectThis && preferAdminHost) preferredMatched = true;
+                    str += '<option value="' + ips[i].address + '" ' + (selectThis ? 'selected' : '') + '>' + ips[i].name + '</option>';
                 }
                 if (!existingFound && actualAddr) {
                     str = '<option value="' + actualAddr + '" selected> Please change INVALID!!' + actualAddr + '</option>' + str;
+                } else if (preferAdminHost && !preferredMatched) {
+                    // Admin host (e.g. hostname or reverse-proxy IP) is not in the host's IP list.
+                    // Offer it as a preselected option so the URL we build later matches what the
+                    // user already uses to reach ioBroker.
+                    str = '<option value="' + adminHost + '" selected>' + adminHost + ' (admin host)</option>' + str;
                 }
 
                 $(id).html(str);

--- a/main.js
+++ b/main.js
@@ -611,7 +611,11 @@ function startAdapter(options) {
     });
 
     adapter.on('ready', () => {
-        initSentry(() => loadExistingAccessories(checkInstanceObject(main)));
+        initSentry(() => loadExistingAccessories(checkInstanceObject(() => {
+            Promise.resolve()
+                .then(() => main())
+                .catch(err => adapter.log.error(`Unhandled error in main(): ${err && err.stack ? err.stack : err}`));
+        })));
     });
 
     return adapter;
@@ -4612,7 +4616,7 @@ function loadExistingAccessories(callback) {
 }
 
 
-function main() {
+async function main() {
     adapter.log.info('Starting Alexa2 adapter ... it can take several minutes to initialize all data. Please be patient! A done message is logged.');
     crashCheckFileName = path.join(__dirname, `crashCheck-${adapter.namespace}.json`);
     if (useCrashCheck) {
@@ -4646,6 +4650,21 @@ function main() {
                 adapter.terminate && adapter.terminate(utils.EXIT_CODES.ADAPTER_REQUESTED_TERMINATION);
             }, 1000);
             return;
+        }
+    }
+
+    if (!adapter.config.proxyOwnIp) {
+        // Prefer the IP the admin instance is bound to: that is the address the user reaches
+        // ioBroker on, and the cookie proxy URL we build from it will work for them.
+        try {
+            const adminObj = await adapter.getForeignObjectAsync('system.adapter.admin.0');
+            const bind = adminObj && adminObj.native && adminObj.native.bind;
+            if (bind && bind !== '0.0.0.0' && bind !== '127.0.0.1' && bind !== '::') {
+                adapter.config.proxyOwnIp = bind;
+                adapter.log.info(`Proxy IP not set, using admin bind IP (${adapter.config.proxyOwnIp}). Override via "Own IP" in instance settings (Proxy tab) if needed.`);
+            }
+        } catch (e) {
+            adapter.log.debug(`Could not read admin bind IP, falling back to interface scan: ${e.message}`);
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -4651,15 +4651,25 @@ function main() {
 
     if (!adapter.config.proxyOwnIp) {
         const ifaces = os.networkInterfaces();
+        const candidates = [];
         for (const eth of Object.keys(ifaces)) {
-            for (let num = 0; num < ifaces[eth].length; num++) {
-                if (ifaces[eth][num].family !== 'IPv6' && ifaces[eth][num].address !== '127.0.0.1' && ifaces[eth][num].address !== '0.0.0.0') {
-                    adapter.config.proxyOwnIp = ifaces[eth][num].address;
-                    adapter.log.info(`Proxy IP not set, use first network interface (${adapter.config.proxyOwnIp}) instead`);
-                    break;
+            for (const iface of ifaces[eth]) {
+                const isIPv4 = iface.family === 'IPv4' || iface.family === 4;
+                if (isIPv4 && !iface.internal) {
+                    candidates.push({ name: eth, address: iface.address });
                 }
             }
-            if (adapter.config.proxyOwnIp) break;
+        }
+        if (candidates.length) {
+            adapter.config.proxyOwnIp = candidates[0].address;
+            if (candidates.length > 1) {
+                const list = candidates.map(c => `${c.address} (${c.name})`).join(', ');
+                adapter.log.info(`Proxy IP not set, picked first non-internal IPv4: ${adapter.config.proxyOwnIp} (${candidates[0].name}). Other candidates: ${list}. If wrong, open instance settings, Proxy tab and select the correct "Own IP".`);
+            } else {
+                adapter.log.info(`Proxy IP not set, picked ${adapter.config.proxyOwnIp} (${candidates[0].name}). Override via "Own IP" in instance settings (Proxy tab) if needed.`);
+            }
+        } else {
+            adapter.log.warn('Proxy IP not set and no non-internal IPv4 interface found. Please set "Own IP" in instance settings (Proxy tab).');
         }
     }
 
@@ -5126,6 +5136,7 @@ function main() {
                 lines[1] = `Please open ${lines[1]}`;
                 proxyUrl = lines[1].substring(lines[1].indexOf('http://'), lines[1].lastIndexOf('/') + 1);
                 restartAdapter = false;
+                lines.push('If the URL above is not reachable from your browser, the picked "Own IP" is wrong. Open instance settings, Proxy tab, set "Own IP" to the address you use to reach ioBroker and save.');
             } else {
                 lines = err.message.split('\n');
             }

--- a/main.js
+++ b/main.js
@@ -4663,11 +4663,16 @@ async function main() {
 
     if (!adapter.config.proxyOwnIp) {
         // Prefer the IP the admin instance is bound to: that is the address the user reaches
-        // ioBroker on, and the cookie proxy URL we build from it will work for them.
+        // ioBroker on, so the cookie proxy URL built from it is reachable from the same browser.
+        // Only when admin runs on THIS host: in a multihost setup admin may sit on a different
+        // machine, and its bind address says nothing about how this host is reached.
         try {
             const adminObj = await adapter.getForeignObjectAsync('system.adapter.admin.0');
             const bind = adminObj && adminObj.native && adminObj.native.bind;
-            if (bind && bind !== '0.0.0.0' && bind !== '127.0.0.1' && bind !== '::') {
+            const adminHost = adminObj && adminObj.common && adminObj.common.host;
+            if (adminHost && adminHost !== adapter.host) {
+                adapter.log.debug(`admin.0 runs on host "${adminHost}", this instance on "${adapter.host}" - not using its bind IP, falling back to interface scan.`);
+            } else if (bind && bind !== '0.0.0.0' && bind !== '127.0.0.1' && bind !== '::') {
                 adapter.config.proxyOwnIp = bind;
                 adapter.log.info(`Proxy IP not set, using admin bind IP (${adapter.config.proxyOwnIp}). Override via "Own IP" in instance settings (Proxy tab) if needed.`);
             }

--- a/main.js
+++ b/main.js
@@ -618,7 +618,11 @@ function startAdapter(options) {
     });
 
     adapter.on('ready', () => {
-        initSentry(() => loadExistingAccessories(checkInstanceObject(main)));
+        initSentry(() => loadExistingAccessories(checkInstanceObject(() => {
+            Promise.resolve()
+                .then(() => main())
+                .catch(err => adapter.log.error(`Unhandled error in main(): ${err && err.stack ? err.stack : err}`));
+        })));
     });
 
     return adapter;
@@ -4620,7 +4624,7 @@ function loadExistingAccessories(callback) {
 }
 
 
-function main() {
+async function main() {
     adapter.log.info('Starting Alexa2 adapter ... it can take several minutes to initialize all data. Please be patient! A done message is logged.');
     crashCheckFileName = path.join(__dirname, `crashCheck-${adapter.namespace}.json`);
     if (useCrashCheck) {
@@ -4654,6 +4658,21 @@ function main() {
                 adapter.terminate && adapter.terminate(utils.EXIT_CODES.ADAPTER_REQUESTED_TERMINATION);
             }, 1000);
             return;
+        }
+    }
+
+    if (!adapter.config.proxyOwnIp) {
+        // Prefer the IP the admin instance is bound to: that is the address the user reaches
+        // ioBroker on, and the cookie proxy URL we build from it will work for them.
+        try {
+            const adminObj = await adapter.getForeignObjectAsync('system.adapter.admin.0');
+            const bind = adminObj && adminObj.native && adminObj.native.bind;
+            if (bind && bind !== '0.0.0.0' && bind !== '127.0.0.1' && bind !== '::') {
+                adapter.config.proxyOwnIp = bind;
+                adapter.log.info(`Proxy IP not set, using admin bind IP (${adapter.config.proxyOwnIp}). Override via "Own IP" in instance settings (Proxy tab) if needed.`);
+            }
+        } catch (e) {
+            adapter.log.debug(`Could not read admin bind IP, falling back to interface scan: ${e.message}`);
         }
     }
 

--- a/main.js
+++ b/main.js
@@ -4659,15 +4659,25 @@ function main() {
 
     if (!adapter.config.proxyOwnIp) {
         const ifaces = os.networkInterfaces();
+        const candidates = [];
         for (const eth of Object.keys(ifaces)) {
-            for (let num = 0; num < ifaces[eth].length; num++) {
-                if (ifaces[eth][num].family !== 'IPv6' && ifaces[eth][num].address !== '127.0.0.1' && ifaces[eth][num].address !== '0.0.0.0') {
-                    adapter.config.proxyOwnIp = ifaces[eth][num].address;
-                    adapter.log.info(`Proxy IP not set, use first network interface (${adapter.config.proxyOwnIp}) instead`);
-                    break;
+            for (const iface of ifaces[eth]) {
+                const isIPv4 = iface.family === 'IPv4' || iface.family === 4;
+                if (isIPv4 && !iface.internal) {
+                    candidates.push({ name: eth, address: iface.address });
                 }
             }
-            if (adapter.config.proxyOwnIp) break;
+        }
+        if (candidates.length) {
+            adapter.config.proxyOwnIp = candidates[0].address;
+            if (candidates.length > 1) {
+                const list = candidates.map(c => `${c.address} (${c.name})`).join(', ');
+                adapter.log.info(`Proxy IP not set, picked first non-internal IPv4: ${adapter.config.proxyOwnIp} (${candidates[0].name}). Other candidates: ${list}. If wrong, open instance settings, Proxy tab and select the correct "Own IP".`);
+            } else {
+                adapter.log.info(`Proxy IP not set, picked ${adapter.config.proxyOwnIp} (${candidates[0].name}). Override via "Own IP" in instance settings (Proxy tab) if needed.`);
+            }
+        } else {
+            adapter.log.warn('Proxy IP not set and no non-internal IPv4 interface found. Please set "Own IP" in instance settings (Proxy tab).');
         }
     }
 
@@ -5134,6 +5144,7 @@ function main() {
                 lines[1] = `Please open ${lines[1]}`;
                 proxyUrl = lines[1].substring(lines[1].indexOf('http://'), lines[1].lastIndexOf('/') + 1);
                 restartAdapter = false;
+                lines.push('If the URL above is not reachable from your browser, the picked "Own IP" is wrong. Open instance settings, Proxy tab, set "Own IP" to the address you use to reach ioBroker and save.');
             } else {
                 lines = err.message.split('\n');
             }


### PR DESCRIPTION
Fixes #1350.

## Problem

When `proxyOwnIp` is empty, `main.js` walks `os.networkInterfaces()` and picks the first non-loopback IPv4. That order is not deterministic across hosts: Docker bridges, secondary NICs, VPN tunnels or virtualization interfaces can win, producing a `Please open http://<ip>:<port>/ ...` URL the user cannot open. In the reported case the URL was built around `192.168.1.3` while the actual ioBroker host was on a different subnet.

Because the enumeration order is stable, the same address is picked again on every restart, so from the user's side it looks like a value that never updates.

## Fix

When `proxyOwnIp` is empty, read `system.adapter.admin.0.native.bind` first via `getForeignObjectAsync`. That value is the address ioBroker is administered on, so the cookie proxy URL built from it is reachable from the same browser the user already has open. Skipped if admin is bound to `0.0.0.0`, `127.0.0.1` or `::` — falls back to the interface scan.

The admin lookup is guarded by a same-host check: `adminObj.common.host` must equal `adapter.host`, otherwise the interface scan runs instead and a debug line names both hosts. In a multihost setup admin may sit on a different machine, whose bind address says nothing about how this host is reached.

`main()` becomes `async` because of the `await`. The ready handler wraps the call in `Promise.resolve().then(...).catch(...)` so an unhandled rejection cannot crash the runtime.

The interface-scan fallback is also tightened:
- Uses Node's `internal` flag instead of string-comparing `127.0.0.1` / `0.0.0.0`.
- Positive IPv4 family check (`'IPv4'` or numeric `4`) — robust across Node versions.
- Logs every candidate when more than one is available.
- Auto-pick log line and the `Please open …` error path mention the override in instance settings → Proxy tab.

No behavior change for users who already have `proxyOwnIp` set.

## Test plan

- `npm test` passes (3 passing, Node 22.22.2).
- On a single-host installation `admin.0` and this instance share `common.host`, so the same-host branch is the one that runs: log shows `Proxy IP not set, using admin bind IP (<ip>). …` and the cookie proxy URL is built from the same IP.
- The differing-host branch falls through to the existing interface scan; that path is not covered by a live multihost test.
