### PR TITLE
Add device reboot button

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Information about the Alexa device
 | isMultiroomMember | Is Multiroom member - If true the device is part of a multiroom device group                | Information, true / false |
 | MultiroomParents  | If this device is part of a multiroom device group this state shows the parent group device | Information               |
 | name              | Name of Alexa Device                                                                        | Information               |
-| SerialNumber      | Serial number of Alexa device                                                               | Information               |
+| SerialNumber      | Serial number of Alexa device                                                               |
 
 ### alexa2.0.Echo-Devices.Serialnumber.Music-Provider.*
 Directly tell Alexa to play Music or a playlist from supported music providers. Actually supported are: My Library, Amazon Music, Tune In. You can also include a multiroom device group name in the phrase to play it on this group (e.g. "SWR3 auf Erdgeschoss")
@@ -208,7 +208,7 @@ Here you find some device preferences.
 
 | State name                       | meaning                                                                                                                                                                    | value                                                                           |
 |----------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| ringNotificationsEnabled         | Shows if the ring notifications are enabled or not and allows to edit it (true/false). The status is updated from cloud with a device configuration interval               | Boolean                                                                         |
+| ringNotificationsEnabled         | Shows if the ring notifications are enabled or not and allows to edit it (true/false). The status is updated from cloud with a device configuration interval               |
 | notificationVolume               | The notification volume set for the device. The value is loaded once on adapter start and then not synced with Cloud services, but changeable                              | number 0..100                                                                   |
 | ascendingAlarmState              | The ascending alarm state set for the device. The value is loaded once on adapter start and then not synced with Cloud services, but changeable                            | Boolean                                                                         |
 | auxPort-*-Direction              | The direction of the AuxPort (when supported). The value is loaded once on adapter start and then not synced with Cloud services, but changeable                           | "INPUT" or "OUTPUT"                                                             |
@@ -257,7 +257,7 @@ You can have one or more timers running on each Alexa device. Because of the ver
 | State name      | meaning                                                                                                      | value      |
 |-----------------|--------------------------------------------------------------------------------------------------------------|------------|
 | activeTimerList | JSON array with the list of active timers containing ID, label and trigger timepoint as unix timestamp in ms | JSON array |
-| nextTimeDate    | Contains the timepoint of the next expected triggering as unix epoch in ms                                   | Number     |
+| nextTimeDate    | Contains the timepoint of the next expected triggering as unix epoch in ms                                   | Number     | Number
 | nextTimerId     | ID of the next timer to trigger                                                                              | String     |
 | stopTimerId     | Control with a timer ID to stop the timer (also stops if the timer is currently ringing!)                    | String     |
 | triggered       | A timer got triggered - in fact it is the "nextTimerId" one                                                  | true/false |

--- a/main.js
+++ b/main.js
@@ -63,6 +63,7 @@ const commands = {
     'singasong': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
     'tellstory': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
     'deviceStop': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
+    'reboot': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
     'calendarToday': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
     'calendarTomorrow': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
     'calendarNext': { val: false, common: { type: 'boolean', read: false, write: true, role: 'button'}},
@@ -2672,6 +2673,7 @@ function createStatesForDevice(device, additionalDeviceData) {
                                     setOrUpdateObject(`${devId}.Commands`, {type: 'channel'});
                                     for (const c of Object.keys(commands)) {
                                         if (c === 'notification' && device.isMultiroomDevice) continue;
+                                        if (c === 'reboot' && (!device.capabilities.includes('ALEXA_DEVICE_REBOOT') || typeof alexa.rebootDevice !== 'function')) continue;
                                         const obj = JSON.parse (JSON.stringify (commands[c]));
                                         if (c === 'sound' && routineSounds && Object.keys(routineSounds).length) {
                                             obj.common.states = routineSounds;
@@ -2681,6 +2683,21 @@ function createStatesForDevice(device, additionalDeviceData) {
                                         }
                                         setOrUpdateObject(`${devId}.Commands.${c}`, {common: obj.common}, obj.val, function (device, command, value) {
                                             command = commands[command].command || command;
+                                            if (command === 'reboot') {
+                                                if (!value) return;
+                                                if (typeof alexa.rebootDevice !== 'function') {
+                                                    adapter.log.error(`${device.serialNumber} Reboot is not supported by the installed alexa-remote2 version`);
+                                                    adapter.setState(`Echo-Devices.${device.serialNumber}.Commands.reboot`, false, true);
+                                                    return;
+                                                }
+                                                alexa.rebootDevice(device, err => {
+                                                    if (err) {
+                                                        adapter.log.error(`${device.serialNumber} Error rebooting device: ${err}`);
+                                                    }
+                                                    adapter.setState(`Echo-Devices.${device.serialNumber}.Commands.reboot`, false, true);
+                                                });
+                                                return;
+                                            }
                                             const commandsToExecute = [];
                                             const speakVolumeCommands = [];
                                             const speakVolumeResetCommands = [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.3.2",
-        "alexa-remote2": "^8.1.0",
+        "alexa-remote2": "^8.1.1",
         "https": "^1.0.0",
         "nearest-color": "^0.4.4",
         "rrule": "^2.8.1"
@@ -1937,9 +1937,9 @@
       }
     },
     "node_modules/alexa-cookie2": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/alexa-cookie2/-/alexa-cookie2-5.0.5.tgz",
-      "integrity": "sha512-ed5S2QEKaZF+RUgXGx6hGHxgzvbgwmyeOmtmmwGj75fcAKMVf+nAmEtZ0dWob6/KLDOD7rkRm3VBXgUbKqSkoQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/alexa-cookie2/-/alexa-cookie2-5.0.6.tgz",
+      "integrity": "sha512-PFFwDRYnxYcS+JEBpen1I+UFxq5bJqh+4ynfFNUQEA7f16aguUEIprd6+GLxWh2zp80i7Nx80wXFkujFh9R+hQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^0.6.0",
@@ -1990,12 +1990,12 @@
       }
     },
     "node_modules/alexa-remote2": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/alexa-remote2/-/alexa-remote2-8.1.0.tgz",
-      "integrity": "sha512-DCs+qCM1309IRVLgzG0juYwtNDl4GE7G+YBgr23NsTAgW/KmKv2OpMTbMY7y34+dHuXgJDOelOpZoar7S5qPGA==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/alexa-remote2/-/alexa-remote2-8.1.1.tgz",
+      "integrity": "sha512-YPeSwfRjv1IKbas5UR22RU5o+DbKwVgXnpU/244p3o7O3FugC6EV7yHm/GKk9Fv2uhYvSEbjFZPEl3q9EarJVw==",
       "license": "MIT",
       "dependencies": {
-        "alexa-cookie2": "^5.0.5",
+        "alexa-cookie2": "^5.0.6",
         "extend": "^3.0.2",
         "https": "^1.0.0",
         "querystring": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/Apollon77/ioBroker.alexa2"
   },
   "dependencies": {
-    "alexa-remote2": "^8.1.0",
+    "alexa-remote2": "^8.1.1",
     "https": "^1.0.0",
     "nearest-color": "^0.4.4",
     "@iobroker/adapter-core": "^3.3.2",


### PR DESCRIPTION
## What does this PR do?

Adds a writable `Commands.reboot` button for Echo devices that advertise the `ALEXA_DEVICE_REBOOT` capability.

When set to `true`, the adapter calls `alexa-remote2.rebootDevice()` and resets the button to `false` after the request. Errors are logged without stopping the adapter.

**The branch depends on the implementation of [#312](https://github.com/Apollon77/alexa-remote/pull/312) in companion `alexa-remote2`. New version needs to be added to Package.json when the new release of alexa.remote2 is available.**

**Depends on: Apollon77/alexa-remote#312**

## Testing

- Node.js syntax check
- ESLint
- Successful real-device test with an Echo device exposing `ALEXA_DEVICE_REBOOT`

No adapter version or release News entries were changed.
